### PR TITLE
fix: rename sessionId to session_id to match common code

### DIFF
--- a/src/app/details/controllers/done.js
+++ b/src/app/details/controllers/done.js
@@ -12,7 +12,7 @@ class DoneController extends BaseController {
       try {
         const apiResponse = await req.axios.get(AUTHORIZE);
 
-        req.session.tokenId = apiResponse?.data?.sessionId;
+        req.session.tokenId = apiResponse?.data?.session_id;
       } catch (e) {
         return next(e);
       }

--- a/src/app/details/controllers/done.test.js
+++ b/src/app/details/controllers/done.test.js
@@ -57,7 +57,7 @@ describe("Done controller", () => {
     });
 
     it("should call session endpoint", () => {});
-    it("should add sessionId to session");
+    it("should add session_id to session");
     it("should use callback");
     context("on session error", () => {});
   });

--- a/src/app/kbv/controllers/load-question.js
+++ b/src/app/kbv/controllers/load-question.js
@@ -12,7 +12,7 @@ class LoadQuestionController extends BaseController {
       try {
         const apiResponse = await req.axios.get(`${QUESTION}`, {
           headers: {
-            sessionId: req.session.tokenId,
+            session_Id: req.session.tokenId,
           },
         });
 

--- a/src/app/kbv/controllers/question.js
+++ b/src/app/kbv/controllers/question.js
@@ -78,7 +78,7 @@ class QuestionController extends BaseController {
           },
           {
             headers: {
-              sessionId: req.session.tokenId,
+              session_id: req.session.tokenId,
             },
           }
         );
@@ -87,7 +87,7 @@ class QuestionController extends BaseController {
 
         const nextQuestion = await req.axios.get(QUESTION, {
           headers: {
-            sessionId: req.session.tokenId,
+            session_id: req.session.tokenId,
           },
         });
 

--- a/test/mocks/mappings/questions-error.json
+++ b/test/mocks/mappings/questions-error.json
@@ -27,7 +27,7 @@
       "response": {
         "status": 200,
         "jsonBody": {
-          "sessionId": "ABADCAFE"
+          "session_id": "ABADCAFE"
         }
       }
     },
@@ -38,7 +38,7 @@
         "method": "GET",
         "url": "/question",
         "headers": {
-          "sessionId": {
+          "session_id": {
             "equalTo": "ABADCAFE"
           },
           "x-scenario-id": {

--- a/test/mocks/mappings/questions.json
+++ b/test/mocks/mappings/questions.json
@@ -38,7 +38,7 @@
         "method": "GET",
         "url": "/question",
         "headers": {
-          "sessionId": {
+          "session_id": {
             "equalTo": "ABADCAFE"
           },
           "x-scenario-id": {
@@ -74,7 +74,7 @@
         "method": "POST",
         "url": "/answer",
         "headers": {
-          "sessionId": {
+          "session_id": {
             "equalTo": "ABADCAFE"
           },
           "x-scenario-id": {
@@ -96,7 +96,7 @@
         "method": "GET",
         "url": "/question",
         "headers": {
-          "sessionId": {
+          "session_id": {
             "equalTo": "ABADCAFE"
           },
           "x-scenario-id": {
@@ -132,7 +132,7 @@
         "method": "POST",
         "url": "/answer",
         "headers": {
-          "sessionId": {
+          "session_id": {
             "equalTo": "ABADCAFE"
           },
           "x-scenario-id": {
@@ -160,7 +160,7 @@
         "method": "GET",
         "url": "/question",
         "headers": {
-          "sessionId": {
+          "session_id": {
             "equalTo": "ABADCAFE"
           },
           "x-scenario-id": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The common API code uses `session_id` instead of `sessionId`. This PR renames all usages to the new format.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
