### PR TITLE
fix: Rename session-id to session_id for non-auth endpoints

### DIFF
--- a/src/app/kbv/controllers/done.js
+++ b/src/app/kbv/controllers/done.js
@@ -9,7 +9,9 @@ const {
 class DoneController extends BaseController {
   async saveValues(req, res, callback) {
     const authCode = await req.axios.get(AUTHORIZATION_CODE, {
-      session_id: req.session.tokenId,
+      headers: {
+        session_id: req.session.tokenId,
+      },
     });
 
     req.session.authParams.authorization_code =

--- a/src/app/kbv/controllers/load-question.js
+++ b/src/app/kbv/controllers/load-question.js
@@ -12,7 +12,7 @@ class LoadQuestionController extends BaseController {
       try {
         const apiResponse = await req.axios.get(`${QUESTION}`, {
           headers: {
-            session_id: req.session.tokenId,
+            "session-id": req.session.tokenId,
           },
         });
 

--- a/src/app/kbv/controllers/question.js
+++ b/src/app/kbv/controllers/question.js
@@ -78,7 +78,7 @@ class QuestionController extends BaseController {
           },
           {
             headers: {
-              session_id: req.session.tokenId,
+              "session-id": req.session.tokenId,
             },
           }
         );
@@ -87,7 +87,7 @@ class QuestionController extends BaseController {
 
         const nextQuestion = await req.axios.get(QUESTION, {
           headers: {
-            session_id: req.session.tokenId,
+            "session-id": req.session.tokenId,
           },
         });
 

--- a/test/mocks/mappings/questions.json
+++ b/test/mocks/mappings/questions.json
@@ -40,7 +40,7 @@
         "method": "GET",
         "url": "/question",
         "headers": {
-          "session_id": {
+          "session-id": {
             "equalTo": "ABADCAFE"
           },
           "x-scenario-id": {
@@ -76,7 +76,7 @@
         "method": "POST",
         "url": "/answer",
         "headers": {
-          "session_id": {
+          "session-id": {
             "equalTo": "ABADCAFE"
           },
           "x-scenario-id": {
@@ -98,7 +98,7 @@
         "method": "GET",
         "url": "/question",
         "headers": {
-          "session_id": {
+          "session-id": {
             "equalTo": "ABADCAFE"
           },
           "x-scenario-id": {
@@ -134,7 +134,7 @@
         "method": "POST",
         "url": "/answer",
         "headers": {
-          "session_id": {
+          "session-id": {
             "equalTo": "ABADCAFE"
           },
           "x-scenario-id": {
@@ -154,7 +154,7 @@
         "method": "GET",
         "url": "/question",
         "headers": {
-          "session_id": {
+          "session-id": {
             "equalTo": "ABADCAFE"
           },
           "x-scenario-id": {
@@ -173,6 +173,9 @@
         "method": "GET",
         "urlPath": "/authorization-code",
         "headers": {
+          "session_id": {
+            "equalTo": "ABADCAFE"
+          },
           "x-scenario-id": {
             "equalTo": "question-success"
           }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Use `snake_case` `session_id` for auth calls, and `kebab-case` `session-id` for KBV CRI specific calls.
 
<!-- Describe the changes in detail - the "what"-->

### Why did it change


## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
