### PR TITLE
fix: Use browser tests without core-stub

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,8 +27,8 @@ jobs:
         run: yarn lint
       - name: Run test and write coverage
         run: yarn test:coverage
-#      - name: Run browser tests
-#        run: npm run test:browser:ci
+      - name: Run browser tests
+        run: npm run test:browser:ci
       - name: Run sonarcloud scan
         if: ${{ github.actor != 'dependabot[bot]' }}
         uses: sonarsource/sonarcloud-github-action@master

--- a/test/browser/features/kbv.feature
+++ b/test/browser/features/kbv.feature
@@ -20,4 +20,4 @@ Feature: Happy path
       Given they have started the KBV journey
       And they should see the first question
       When they have answered all the questions successfully
-      Then they should see the done page
+      Then they should be redirected

--- a/test/browser/pages/index.js
+++ b/test/browser/pages/index.js
@@ -2,5 +2,6 @@ module.exports = {
   DetailsPage: require("./details.js"),
   DonePage: require("./done.js"),
   QuestionPage: require("./question.js"),
+  RelyingPartyPage: require("./relying-party.js"),
   ErrorPage: require("./error.js"),
 };

--- a/test/browser/pages/relying-party.js
+++ b/test/browser/pages/relying-party.js
@@ -1,0 +1,19 @@
+module.exports = class PlaywrightDevPage {
+  /**
+   * @param {import('@playwright/test').Page} page
+   */
+  constructor(page) {
+    this.page = page;
+  }
+
+  async goto() {
+    this.startingUrl =
+      "http://localhost:5020/oauth2/authorize?request=lorem&client_id=standalone";
+
+    await this.page.goto(this.startingUrl);
+  }
+
+  async isRedirectPage() {
+    return await this.page.url().startsWith("http://example.net");
+  }
+};

--- a/test/browser/step_definitions/details.js
+++ b/test/browser/step_definitions/details.js
@@ -1,18 +1,23 @@
 const { Given, When, Then } = require("@cucumber/cucumber");
 
-const { DetailsPage } = require("../pages");
+const { RelyingPartyPage } = require("../pages");
+const { expect } = require("chai");
 
-Given(/^^([A-Za-z ])+is using the system$/, async function (name) {
+Given(/^([A-Za-z ])+is using the system$/, async function (name) {
   this.user = this.allUsers[name];
+  const rpPage = new RelyingPartyPage(this.page);
+
+  await rpPage.goto();
 });
 
 Given(
   "they have provided their details",
   { timeout: 10 * 1000 },
-  async function () {
-    const detailsPage = new DetailsPage(this.page);
-
-    await detailsPage.goto();
-    await detailsPage.fillOutDetails();
-  }
+  async function () {}
 );
+
+Then("they should be redirected", async function () {
+  const rpPage = new RelyingPartyPage(this.page);
+
+  expect(await rpPage.isRedirectPage()).to.be.true;
+});


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Restore browser tests by linking directly into the oauth path, as opposed to requiring core-stub.

This means they are not currently dual purpose and can not be run against an environment.

But it does mean there are browser tests that can be run.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-XXXX](https://govukverify.atlassian.net/browse/KBV-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
