### PR TITLE
[KBV-457] Dockerfile for fargate deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM node:16.14.2-alpine3.15@sha256:38bc06c682ae1f89f4c06a5f40f7a07ae438ca437a2a04cf773e66960b2d75bc AS builder
+
+WORKDIR /app
+
+RUN [ "yarn", "set", "version", "1.22.17" ]
+
+COPY .yarn ./.yarn
+COPY /src ./src
+COPY package.json yarn.lock .yarnrc.yml ./
+
+RUN yarn install
+RUN yarn build
+
+# 'yarn install --production' does not prune test packages which are necessary
+# to build the app. So delete nod_modules and reinstall only production packages.
+RUN [ "rm", "-rf", "node_modules" ]
+RUN yarn install --production
+
+FROM node:16.14.2-alpine3.15@sha256:38bc06c682ae1f89f4c06a5f40f7a07ae438ca437a2a04cf773e66960b2d75bc AS final
+
+RUN ["apk", "--no-cache", "upgrade"]
+RUN ["apk", "add", "--no-cache", "tini"]
+RUN [ "yarn", "set", "version", "1.22.17" ]
+
+WORKDIR /app
+
+# Copy in compile assets and deps from build container
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/src ./src
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/yarn.lock ./
+
+
+ENV PORT 8080
+EXPOSE 8080
+
+ENTRYPOINT ["tini", "--"]
+
+CMD ["yarn", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:16.14.2-alpine3.15@sha256:38bc06c682ae1f89f4c06a5f40f7a07ae438ca437a2a
 
 WORKDIR /app
 
-RUN [ "yarn", "set", "version", "1.22.17" ]
+RUN [ "yarn", "set", "version", "1.22.18" ]
 
 COPY .yarn ./.yarn
 COPY /src ./src
@@ -20,7 +20,7 @@ FROM node:16.14.2-alpine3.15@sha256:38bc06c682ae1f89f4c06a5f40f7a07ae438ca437a2a
 
 RUN ["apk", "--no-cache", "upgrade"]
 RUN ["apk", "add", "--no-cache", "tini"]
-RUN [ "yarn", "set", "version", "1.22.17" ]
+RUN [ "yarn", "set", "version", "1.22.18" ]
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM node:16.14.2-alpine3.15@sha256:38bc06c682ae1f89f4c06a5f40f7a07ae438ca437a2a
 
 WORKDIR /app
 
-COPY /src ./src
 COPY .yarn ./.yarn
 COPY package.json yarn.lock .yarnrc.yml ./
+COPY /src ./src
 
 RUN yarn install
 RUN yarn build
@@ -24,9 +24,9 @@ WORKDIR /app
 # Copy in compile assets and deps from build container
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
-COPY --from=builder /app/src ./src
 COPY --from=builder /app/package.json ./
 COPY --from=builder /app/yarn.lock ./
+COPY --from=builder /app/src ./src
 
 
 ENV PORT 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,8 @@ FROM node:16.14.2-alpine3.15@sha256:38bc06c682ae1f89f4c06a5f40f7a07ae438ca437a2a
 
 WORKDIR /app
 
-RUN [ "yarn", "set", "version", "1.22.18" ]
-
-COPY .yarn ./.yarn
 COPY /src ./src
+COPY .yarn ./.yarn
 COPY package.json yarn.lock .yarnrc.yml ./
 
 RUN yarn install
@@ -14,13 +12,12 @@ RUN yarn build
 # 'yarn install --production' does not prune test packages which are necessary
 # to build the app. So delete nod_modules and reinstall only production packages.
 RUN [ "rm", "-rf", "node_modules" ]
-RUN yarn install --production
+RUN yarn install --production --frozen-lockfile
 
 FROM node:16.14.2-alpine3.15@sha256:38bc06c682ae1f89f4c06a5f40f7a07ae438ca437a2a04cf773e66960b2d75bc AS final
 
 RUN ["apk", "--no-cache", "upgrade"]
 RUN ["apk", "add", "--no-cache", "tini"]
-RUN [ "yarn", "set", "version", "1.22.18" ]
 
 WORKDIR /app
 
@@ -33,7 +30,7 @@ COPY --from=builder /app/yarn.lock ./
 
 
 ENV PORT 8080
-EXPOSE 8080
+EXPOSE $PORT
 
 ENTRYPOINT ["tini", "--"]
 


### PR DESCRIPTION
## Proposed changes

Create Dockerfile suitable for deployment to Fargate: ECS 

### What changed

New Dockerfile created on node:16.14.2-alpine3.15, tested locally

### Why did it change

Required for migration

### Issue tracking

- [KBV-457](https://govukverify.atlassian.net/browse/KBV-457)
