### PR TITLE
feat: Use authorization code from common-express

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "axios": "0.26.0",
     "cfenv": "1.2.4",
     "copyfiles": "2.4.1",
-    "di-ipv-cri-common-express": "alphagov/di-ipv-cri-common-express.git#v0.0.5",
+    "di-ipv-cri-common-express": "alphagov/di-ipv-cri-common-express.git#v0.0.6",
     "dotenv": "16.0.0",
     "express": "4.17.3",
     "express-async-errors": "3.1.1",

--- a/src/app.js
+++ b/src/app.js
@@ -49,6 +49,7 @@ setAPIConfig({
   app,
   baseUrl: API.BASE_URL,
   sessionPath: API.PATHS.SESSION,
+  authorizationPath: API.PATHS.AUTHORIZATION,
 });
 
 setOAuthPaths({ app, entryPointPath: APP.PATHS.KBV });

--- a/src/app/kbv/steps.js
+++ b/src/app/kbv/steps.js
@@ -1,4 +1,3 @@
-const done = require("./controllers/done");
 const question = require("./controllers/question");
 const loadQuestion = require("./controllers/load-question");
 
@@ -20,8 +19,8 @@ module.exports = {
     next: question.prototype.next,
   },
   "/done": {
-    controller: done,
     skip: true,
+    noPost: true,
     next: "/oauth2/callback",
   },
 };

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -7,7 +7,7 @@ module.exports = {
       SESSION: "/session",
       QUESTION: "/question",
       ANSWER: "/answer",
-      AUTHORIZATION_CODE: "/authorization-code",
+      AUTHORIZATION: "/authorization",
     },
   },
   APP: {

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -1,7 +1,8 @@
 module.exports = {
-  setAPIConfig: ({ app, baseUrl, sessionPath }) => {
+  setAPIConfig: ({ app, baseUrl, sessionPath, authorizationPath }) => {
     app.set("API.BASE_URL", baseUrl);
     app.set("API.PATHS.SESSION", sessionPath);
+    app.set("API.PATHS.AUTHORIZATION", authorizationPath);
   },
 
   setOAuthPaths: ({ app, entryPointPath }) => {

--- a/src/lib/settings.test.js
+++ b/src/lib/settings.test.js
@@ -20,9 +20,21 @@ describe("settings", () => {
     });
 
     it("should set 'API.PATHS.SESSION", () => {
-      setAPIConfig({ app, sessionPath: "/api/auth" });
+      setAPIConfig({ app, sessionPath: "/api/session" });
 
-      expect(app.set).to.have.been.calledWith("API.PATHS.SESSION", "/api/auth");
+      expect(app.set).to.have.been.calledWith(
+        "API.PATHS.SESSION",
+        "/api/session"
+      );
+    });
+
+    it("should set 'API.PATHS.SESSION", () => {
+      setAPIConfig({ app, authorizationPath: "/api/authorization" });
+
+      expect(app.set).to.have.been.calledWith(
+        "API.PATHS.AUTHORIZATION",
+        "/api/authorization"
+      );
     });
   });
 

--- a/test/browser/pages/relying-party.js
+++ b/test/browser/pages/relying-party.js
@@ -14,6 +14,12 @@ module.exports = class PlaywrightDevPage {
   }
 
   async isRedirectPage() {
-    return await this.page.url().startsWith("http://example.net");
+    const url = this.page.url();
+
+    const isCorrectPage =
+      url.startsWith("http://example.net") &&
+      url.endsWith("client_id=standalone&state=sT%40t3&code=FACEFEED");
+
+    return isCorrectPage;
   }
 };

--- a/test/mocks/mappings/questions.json
+++ b/test/mocks/mappings/questions.json
@@ -170,8 +170,8 @@
       "scenarioName": "question-success",
       "requiredScenarioState": "AuthCode",
       "request": {
-        "method": "GET",
-        "urlPath": "/authorization-code",
+        "method": "POST",
+        "urlPath": "/authorization",
         "headers": {
           "session_id": {
             "equalTo": "ABADCAFE"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1353,9 +1353,9 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
-di-ipv-cri-common-express@alphagov/di-ipv-cri-common-express.git#v0.0.5:
-  version "0.0.5"
-  resolved "https://codeload.github.com/alphagov/di-ipv-cri-common-express/tar.gz/ed438d1a0dd24e91d38a5180f5f01acd0af8ac36"
+di-ipv-cri-common-express@alphagov/di-ipv-cri-common-express.git#v0.0.6:
+  version "0.0.6"
+  resolved "https://codeload.github.com/alphagov/di-ipv-cri-common-express/tar.gz/f83e4a8202d55a52bc85e866be2f1ef8c84f515a"
 
 diff@5.0.0, diff@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
- Update usage of common express middleware so as to use the new
  authorization code endpoint
- Redirect from done to /oauth/callback when done

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

This updates `kbv-front` to use the common code for retrieving the `authorization code`. 
<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-XXXX](https://govukverify.atlassian.net/browse/KBV-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
