### PR TITLE
fix: Server crash & increase test coverage

### DIFF
--- a/src/app/kbv/controllers/question.js
+++ b/src/app/kbv/controllers/question.js
@@ -95,7 +95,7 @@ class QuestionController extends BaseController {
           req.session.question = nextQuestion.data;
         }
       } catch (e) {
-        callback(e);
+        return callback(e);
       }
 
       callback();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

If the response from the question or answer endpoints returns an error, then the error response was not being handled correctly, and the server was crashing.

The correct way to deal with this is to return from the middleware with any error, and let Express handle it only once.

Test coverage was also increased.

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed
### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
