### PR TITLE
Feat/error redirecting

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -64,3 +64,5 @@ router.use("/kbv", require("./app/kbv"));
 router.use("^/$", (req, res) => {
   res.render("index");
 });
+
+router.use(commonExpress.lib.errorHandling.redirectAsErrorToCallback);

--- a/test/browser/features/errors.feature
+++ b/test/browser/features/errors.feature
@@ -7,7 +7,16 @@ Feature: Error handling
     Given Error Ethem is using the system
     And they have provided their details
 
-  @mock-api:question-error
-  Scenario: API error
+  @mock-api:session-error
+  Scenario: Session error
     Given they have started the KBV journey
-    Then they should see an error page
+    And there is an immediate error
+    Then they should see the unrecoverable error page
+
+  @mock-api:answer-error @wip
+  Scenario: Error on answering first question
+    Given they have started the KBV journey
+    And they have continued to questions
+    And they should see the first question
+    When they answer the first question
+    Then they should be redirected as an error

--- a/test/browser/features/kbv.feature
+++ b/test/browser/features/kbv.feature
@@ -28,4 +28,4 @@ Feature: Happy path
       And they have continued to questions
       And they should see the first question
       When they have answered all the questions successfully
-      Then they should be redirected
+      Then they should be redirected as a success

--- a/test/browser/pages/relying-party.js
+++ b/test/browser/pages/relying-party.js
@@ -36,4 +36,13 @@ module.exports = class PlaywrightDevPage {
       searchParams.get("code") === "FACEFEED"
     );
   }
+
+  hasErrorQueryParams() {
+    const { searchParams } = new URL(this.page.url());
+
+    return (
+      searchParams.get("error") === "server_error" &&
+      searchParams.get("error_description") === "gateway"
+    );
+  }
 };

--- a/test/browser/pages/relying-party.js
+++ b/test/browser/pages/relying-party.js
@@ -22,4 +22,18 @@ module.exports = class PlaywrightDevPage {
 
     return isCorrectPage;
   }
+
+  isRelyingPartyServer() {
+    return new URL(this.page.url()).origin === "http://example.net";
+  }
+
+  hasSuccessQueryParams() {
+    const { searchParams } = new URL(this.page.url());
+
+    return (
+      searchParams.get("client_id") === "standalone" &&
+      searchParams.get("state") === "sT@t3" &&
+      searchParams.get("code") === "FACEFEED"
+    );
+  }
 };

--- a/test/browser/step_definitions/details.js
+++ b/test/browser/step_definitions/details.js
@@ -16,8 +16,10 @@ Given(
   async function () {}
 );
 
-Then("they should be redirected", async function () {
+Then("they should be redirected as a success", async function () {
   const rpPage = new RelyingPartyPage(this.page);
 
-  expect(await rpPage.isRedirectPage()).to.be.true;
+  expect(await rpPage.isRelyingPartyServer()).to.be.true;
+
+  expect(rpPage.hasSuccessQueryParams()).to.be.true;
 });

--- a/test/browser/step_definitions/details.js
+++ b/test/browser/step_definitions/details.js
@@ -16,10 +16,18 @@ Given(
   async function () {}
 );
 
-Then("they should be redirected as a success", async function () {
+Then("they should be redirected as a success", function () {
   const rpPage = new RelyingPartyPage(this.page);
 
-  expect(await rpPage.isRelyingPartyServer()).to.be.true;
+  expect(rpPage.isRelyingPartyServer()).to.be.true;
 
   expect(rpPage.hasSuccessQueryParams()).to.be.true;
+});
+
+Then("they should be redirected as an error", function () {
+  const rpPage = new RelyingPartyPage(this.page);
+
+  expect(rpPage.isRelyingPartyServer()).to.be.true;
+
+  expect(rpPage.hasErrorQueryParams()).to.be.true;
 });

--- a/test/browser/step_definitions/errors.js
+++ b/test/browser/step_definitions/errors.js
@@ -4,7 +4,9 @@ const { expect } = require("chai");
 
 const { ErrorPage } = require("../pages");
 
-Then("they should see an error page", async function () {
+When("there is an immediate error", () => {});
+
+Then("they should see the unrecoverable error page", async function () {
   const errorPage = new ErrorPage(this.page);
 
   const errorTitle = await errorPage.getErrorTitle();

--- a/test/mocks/mappings/answer-error.json
+++ b/test/mocks/mappings/answer-error.json
@@ -1,0 +1,120 @@
+{
+  "mappings": [
+    {
+      "scenarioName": "answer-error",
+      "newScenarioState": "Started",
+      "request": {
+        "method": "GET",
+        "url": "/__reset/answer-error"
+      },
+      "response": {
+        "status": 200
+      }
+    },
+    {
+      "scenarioName": "answer-error",
+      "requiredScenarioState": "Started",
+      "newScenarioState": "FirstQuestion",
+      "request": {
+        "method": "POST",
+        "url": "/session",
+        "headers": {
+          "x-scenario-id": {
+            "equalTo": "answer-error"
+          }
+        },
+        "bodyPatterns": [
+          {
+            "equalToJson": {
+              "request": "${json-unit.any-string}",
+              "client_id": "${json-unit.any-string}"
+            },
+            "ignoreArrayOrder": true
+          }
+        ]
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": {
+          "session_id": "ABADCAFE",
+          "state": "sT@t3",
+          "redirect_uri": "http://example.net/return"
+        }
+      }
+    },
+    {
+      "scenarioName": "answer-error",
+      "requiredScenarioState": "FirstQuestion",
+      "request": {
+        "method": "GET",
+        "url": "/question",
+        "headers": {
+          "session-id": {
+            "equalTo": "ABADCAFE"
+          },
+          "x-scenario-id": {
+            "equalTo": "answer-error"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": {
+          "questionID": "Q00051",
+          "text": "In which month and year did you open one of your current accounts",
+          "toolTip": "",
+          "answerFormat": {
+            "identifier": "A00051",
+            "fieldType": "R ",
+            "answerList": [
+              "01 / 2022",
+              "05 / 1999",
+              "12 / 2020",
+              "07 / 2012",
+              "NONE OF THE ABOVE / DOES NOT APPLY"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "scenarioName": "answer-error",
+      "requiredScenarioState": "FirstQuestion",
+      "newScenarioState": "LastQuestion",
+      "request": {
+        "method": "POST",
+        "url": "/answer",
+        "headers": {
+          "session-id": {
+            "equalTo": "ABADCAFE"
+          },
+          "x-scenario-id": {
+            "equalTo": "answer-error"
+          },
+          "Content-Type": {
+            "equalTo": "application/json"
+          }
+        },
+        "bodyPatterns": [
+          {
+            "equalToJson": {
+              "questionId": "Q00051",
+              "answer": "${json-unit.any-string}"
+            },
+            "ignoreArrayOrder": true
+          }
+        ]
+      },
+      "response": {
+        "status": 500,
+        "jsonBody": {
+          "redirect_uri": "http://example.org",
+          "oauth_error": {
+            "error_description": "Invalid request JWT",
+            "error": "invalid_request_object"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/test/mocks/mappings/answer-error.json
+++ b/test/mocks/mappings/answer-error.json
@@ -108,10 +108,10 @@
       "response": {
         "status": 500,
         "jsonBody": {
-          "redirect_uri": "http://example.org",
+          "redirect_uri": "http://example.net",
           "oauth_error": {
-            "error_description": "Invalid request JWT",
-            "error": "invalid_request_object"
+            "error_description": "gateway",
+            "error": "server_error"
           }
         }
       }

--- a/test/mocks/mappings/session-error.json
+++ b/test/mocks/mappings/session-error.json
@@ -1,0 +1,41 @@
+{
+  "mappings": [
+    {
+      "scenarioName": "session-error",
+      "newScenarioState": "Started",
+      "request": {
+        "method": "GET",
+        "url": "/__reset/session-error"
+      },
+      "response": {
+        "status": 200
+      }
+    },
+    {
+      "scenarioName": "session-error",
+      "requiredScenarioState": "Started",
+      "newScenarioState": "FirstQuestion",
+      "request": {
+        "method": "POST",
+        "url": "/session",
+        "headers": {
+          "x-scenario-id": {
+            "equalTo": "session-error"
+          }
+        },
+        "bodyPatterns": [
+          {
+            "equalToJson": {
+              "request": "${json-unit.any-string}",
+              "client_id": "${json-unit.any-string}"
+            },
+            "ignoreArrayOrder": true
+          }
+        ]
+      },
+      "response": {
+        "status": 500
+      }
+    }
+  ]
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Credential issuers should redirect back to the relying party if they have been provided with a redirect_uri.

Otherwise they should display the generic error page.

This is a one liner from common express, the rest is mocks & browser test.

This uses the expected error response body as defined in passport back - https://github.com/alphagov/di-ipv-cri-uk-passport-back/blob/main/lambdas/jwtauthorizationrequest/src/test/java/uk/gov/di/ipv/cri/passport/jwtauthorizationrequest/JwtAuthorizationRequestHandlerTest.java#L252-L255

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-XXXX](https://govukverify.atlassian.net/browse/KBV-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
