### PR TITLE
Implement Fargate scaling

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -454,6 +454,42 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-KBVFront-API-GW-AccessLogs
 
+# Autoscaling
+# The number of pods will increase when the configured CPU utilization is breached for more than 3 minutes.
+# Scaling down will occur after 15 minutes of 90% utilization of the configured CPU utilization.
+
+  ECSAutoScalingTarget:
+    Type: AWS::ApplicationAutoScaling::ScalableTarget
+    Properties:
+      MaxCapacity: 3
+      MinCapacity: 1
+      ResourceId: !Join
+        - '/'
+        - - "service"
+          - !Ref   KBVFrontEcsCluster
+          - !GetAtt KBVFrontEcsService.Name
+      RoleARN: !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService"
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+
+  ECSAutoScalingPolicy:
+    DependsOn: ECSAutoScalingTarget
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: ECSAutoScalingPolicy
+      PolicyType: TargetTrackingScaling
+      ResourceId: !Join
+        - '/'
+        - - "service"
+          - !Ref   KBVFrontEcsCluster
+          - !GetAtt KBVFrontEcsService.Name
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+      TargetTrackingScalingPolicyConfiguration:
+        PredefinedMetricSpecification:
+          PredefinedMetricType: ECSServiceAverageCPUUtilization
+        TargetValue: 0.7
+
 Outputs:
   KBVFrontUrl:
     Description: >-

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -35,6 +35,7 @@ Conditions:
     - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, integration ]
     - !Equals [ !Ref Environment, production ]
+  IsProduction: !Equals [ !Ref Environment, production ]
   UsePermissionsBoundary:
     Fn::Not:
       - Fn::Equals:
@@ -459,6 +460,7 @@ Resources:
 # Scaling down will occur after 15 minutes of 90% utilization of the configured CPU utilization.
 
   ECSAutoScalingTarget:
+    Condition: IsProduction
     Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
       MaxCapacity: 3
@@ -473,6 +475,7 @@ Resources:
       ServiceNamespace: ecs
 
   ECSAutoScalingPolicy:
+    Condition: IsProduction
     DependsOn: ECSAutoScalingTarget
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -491,7 +491,7 @@ Resources:
       TargetTrackingScalingPolicyConfiguration:
         PredefinedMetricSpecification:
           PredefinedMetricType: ECSServiceAverageCPUUtilization
-        TargetValue: 0.7
+        TargetValue: 70.0
 
 Outputs:
   KBVFrontUrl:


### PR DESCRIPTION
Co-authored-by: Claude Paret <claude.paret@digital.cabinet-office.gov.uk>

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
Fargate container should scale up when there is high load
### What changed

Implement container scaling config
Currently set to 1 as default, and scales up to 3.  The max number will need reviewing after some load-testing.
Currently scaling is set when CPU load exceeds 70% for more than 3 mins

<!-- Describe the changes in detail - the "what"-->

### Why did it change
Require frontend capacity scaling with load in production.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PLAT-158](https://govukverify.atlassian.net/browse/PLAT-158)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed


