### PR TITLE
chore: Standardise browser test invocation between CRIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "test": "mocha",
     "test:coverage": "nyc --reporter=lcov --reporter=text-summary yarn test",
     "test:watch": "mocha --watch",
-    "mocks": "yarn run wiremock --port 8090 --root-dir test/mocks",
-    "test:browser": "wait-on tcp:8090 tcp:5020 && cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js  --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js",
-    "test:browser:only": "wait-on tcp:8090 tcp:5020 && cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js  --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js --tags @only",
+    "mocks": "yarn run wiremock --port 8020 --root-dir test/mocks",
+    "test:browser": "wait-on tcp:8020 tcp:5020 && MOCK_API=true cucumber-js --config test/browser/cucumber.js --tags \"not @skip\"",
     "test:browser:ci": "npm-run-all -p -r start:ci mocks test:browser",
+    "test:browser:only": "wait-on tcp:8020 tcp:5020 && MOCK_API=true cucumber-js --config test/browser/cucumber.js --tags \"@only and not @skip\"",
     "test:browser:ci:only": "npm-run-all -p -r start:ci mocks test:browser:only",
     "check-translation": "node node_modules/di-ipv-cri-common-express/scripts/checkTranslations.js"
   },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Standardise the browser test runner tasks between the 3 common CRIs

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
