### PR TITLE
refactor: Send session_id & session-id for BE refactoring

### DIFF
--- a/src/app/kbv/controllers/abandon.js
+++ b/src/app/kbv/controllers/abandon.js
@@ -28,6 +28,7 @@ class AbandonController extends BaseController {
       {
         headers: {
           "session-id": req.session.tokenId,
+          session_id: req.session.tokenId,
         },
       }
     );

--- a/src/app/kbv/controllers/abandon.test.js
+++ b/src/app/kbv/controllers/abandon.test.js
@@ -36,7 +36,16 @@ describe("Abandon controller", () => {
 
         await abandonController.saveValues(req, res, next);
         expect(next).to.have.been.calledOnce;
-        expect(req.axios.post).to.have.been.calledWith(ABANDON, {});
+        expect(req.axios.post).to.have.been.calledWithExactly(
+          ABANDON,
+          {},
+          {
+            headers: {
+              "session-id": req.session.tokenId,
+              session_id: req.session.tokenId,
+            },
+          }
+        );
       });
 
       it("should not call abandon endpoint", async () => {

--- a/src/app/kbv/controllers/load-question.js
+++ b/src/app/kbv/controllers/load-question.js
@@ -13,6 +13,7 @@ class LoadQuestionController extends BaseController {
         const apiResponse = await req.axios.get(`${QUESTION}`, {
           headers: {
             "session-id": req.session.tokenId,
+            session_id: req.session.tokenId,
           },
         });
 

--- a/src/app/kbv/controllers/question.js
+++ b/src/app/kbv/controllers/question.js
@@ -56,6 +56,7 @@ class QuestionController extends BaseController {
           {
             headers: {
               "session-id": req.session.tokenId,
+              session_id: req.session.tokenId,
             },
           }
         );
@@ -65,6 +66,7 @@ class QuestionController extends BaseController {
         const nextQuestion = await req.axios.get(QUESTION, {
           headers: {
             "session-id": req.session.tokenId,
+            session_id: req.session.tokenId,
           },
         });
 

--- a/src/app/kbv/controllers/question.test.js
+++ b/src/app/kbv/controllers/question.test.js
@@ -166,7 +166,7 @@ describe("Question controller", () => {
       expect(req.axios.post).to.have.been.calledWith(
         "/answer",
         { questionId: "Q1", answer: "A1" },
-        { headers: { "session-id": "abcdef" } }
+        { headers: { "session-id": "abcdef", session_id: "abcdef" } }
       );
     });
 
@@ -183,7 +183,7 @@ describe("Question controller", () => {
 
       expect(req.axios.get).to.have.been.called;
       expect(req.axios.get).to.have.been.calledWith("/question", {
-        headers: { "session-id": "abcdef" },
+        headers: { "session-id": "abcdef", session_id: "abcdef" },
       });
     });
 

--- a/test/mocks/mappings/questions.json
+++ b/test/mocks/mappings/questions.json
@@ -52,6 +52,9 @@
           "session-id": {
             "equalTo": "ABADCAFE"
           },
+          "session_id": {
+            "equalTo": "ABADCAFE"
+          },
           "x-scenario-id": {
             "equalTo": "question-success"
           }
@@ -88,6 +91,9 @@
           "session-id": {
             "equalTo": "ABADCAFE"
           },
+          "session_id": {
+            "equalTo": "ABADCAFE"
+          },
           "x-scenario-id": {
             "equalTo": "question-success"
           },
@@ -117,6 +123,9 @@
         "url": "/question",
         "headers": {
           "session-id": {
+            "equalTo": "ABADCAFE"
+          },
+          "session_id": {
             "equalTo": "ABADCAFE"
           },
           "x-scenario-id": {
@@ -155,6 +164,9 @@
           "session-id": {
             "equalTo": "ABADCAFE"
           },
+          "session_id": {
+            "equalTo": "ABADCAFE"
+          },
           "x-scenario-id": {
             "equalTo": "question-success"
           }
@@ -184,6 +196,9 @@
           "session-id": {
             "equalTo": "ABADCAFE"
           },
+          "session_id": {
+            "equalTo": "ABADCAFE"
+          },
           "x-scenario-id": {
             "equalTo": "question-success"
           }
@@ -201,6 +216,9 @@
         "urlPath": "/authorization",
         "headers": {
           "session-id": {
+            "equalTo": "ABADCAFE"
+          },
+          "session_id": {
             "equalTo": "ABADCAFE"
           },
           "x-scenario-id": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

There is currently an inconsistency with the common API endpoints - some of them use `session-id` and some of them use `session_id`.

In order to non-breaking refactoring on the API - all the API requests will temporarily provide both parameters. Once the refactoring is complete, the unused parameter can be removed.


<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-962](https://govukverify.atlassian.net/browse/OJ-962)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
