### PR TITLE
refactor: Use global required validator for question

### DIFF
--- a/src/lib/dynamic/question.js
+++ b/src/lib/dynamic/question.js
@@ -26,9 +26,6 @@ function questionToTranslations(question) {
         legend: question.text,
         label: question.text,
         hint: question.toolTip,
-        validation: {
-          default: "You need to answer the question",
-        },
         items: answerListToTranslatedItems(question.answerFormat.answerList),
       },
     },

--- a/src/lib/dynamic/question.test.js
+++ b/src/lib/dynamic/question.test.js
@@ -42,17 +42,6 @@ describe("question", () => {
 
       expect(hint).to.equal(`${question.toolTip}`);
     });
-    it("should use i18n for default validation error", () => {
-      const {
-        fields: {
-          Q1: {
-            validation: { default: defaultValidation },
-          },
-        },
-      } = dynamicQuestion.questionToTranslations(question);
-
-      expect(defaultValidation).to.equal("You need to answer the question");
-    });
 
     it("should contain items", () => {
       const {

--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -57,3 +57,5 @@ error:
     contactMeLink: "Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd)"
     buttonText: "Ewch i hafan GOV.UK"
     buttonLink: "https://www.gov.uk/"
+validation:
+  required: "Mae angen i chi ateb y cwestiwn"

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -58,3 +58,5 @@ error:
     contactMeLink: Contact the GOV.UK account team (opens in a new tab)
     buttonText: Go to the GOV.UK homepage
     buttonLink: https://www.gov.uk/
+validation:
+  required: "You need to answer the question"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The KBV CRI mostly displays dynamic questions. This change sets a default validation message for all required fields. The only other field in this CRI is on the abandon page, and that already has a required message set.

This approach of overriding the default will allow for individual questions to have their own validation message if needed.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
