### PR TITLE
Use i18next

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "cfenv": "1.2.4",
     "connect-dynamodb": "^2.0.4",
     "copyfiles": "2.4.1",
-    "di-ipv-cri-common-express": "alphagov/di-ipv-cri-common-express.git#v0.0.31",
+    "di-ipv-cri-common-express": "alphagov/di-ipv-cri-common-express.git#v0.0.36",
     "dotenv": "16.0.3",
     "express": "4.18.2",
     "express-async-errors": "3.1.1",

--- a/src/app.js
+++ b/src/app.js
@@ -15,6 +15,7 @@ const setAxiosDefaults = commonExpress.lib.axios;
 const { setAPIConfig, setOAuthPaths } = require("./lib/settings");
 const { setGTM } = require("di-ipv-cri-common-express/src/lib/settings");
 const { getGTM } = require("di-ipv-cri-common-express/src/lib/locals");
+const { setI18n } = require("di-ipv-cri-common-express/src/lib/i18next");
 
 const {
   API,
@@ -79,6 +80,14 @@ const { app, router } = setup({
     app.use(setHeaders);
   },
   dev: true,
+});
+
+setI18n({
+  router,
+  config: {
+    secure: true,
+    cookieDomain: APP.ANALYTICS.DOMAIN,
+  },
 });
 
 app.get("nunjucks").addGlobal("getContext", function () {

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -43,6 +43,9 @@ preConfiguredValues:
       label: "Decerqueria, Kenneth - Dilysu lefel 1"
 abandonRadio:
   label: "Beth hoffech chi ei wneud?"
+  legend: "Beth hoffech chi ei wneud?"
+  hint: ""
+  content: ""
   validation:
     required: "Mae'n rhaid i chi ddewis opsiwn i barhau"
   items:

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -19,6 +19,7 @@ simplifiedQuestion:
   abandon: "<a href='/kbv/abandon' class='govuk-link' data-id='abandon'>Ni allaf ateb y cwestiwn hwn</a>"
 abandonCheck:
   title: "Rhaid i chi ateb pob cwestiwn diogelwch i brofi pwy ydych chi"
+  h1: "Rhaid i chi ateb pob cwestiwn diogelwch i brofi pwy ydych chi"
   content:
     - "Ni allwch hepgor unrhyw gwestiynau."
   contact: "<p><a href='https://signin.account.gov.uk/contact-us?supportType=PUBLIC' class='govuk-link' rel='noreferrer noopener' target='_blank'>Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd)</a></p>"

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -52,6 +52,9 @@ preConfiguredValues:
 
 abandonRadio:
   label: What would you like to do?
+  legend: What would you like to do?
+  hint: ""
+  content: ""
   validation:
     required: You must choose an option to continue
   items:

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -22,6 +22,7 @@ simplifiedQuestion:
 
 abandonCheck:
   title: You must answer all security questions to prove your identity
+  h1: You must answer all security questions to prove your identity
   content:
     - You cannot skip any questions.
   contact: "<p><a href='https://signin.account.gov.uk/contact-us?supportType=PUBLIC' class='govuk-link' rel='noreferrer noopener' target='_blank'>Contact the GOV.UK account team (opens in a new tab)</a></p>"

--- a/src/views/kbv/abandon.html
+++ b/src/views/kbv/abandon.html
@@ -1,5 +1,6 @@
-{% extends "form-template.njk" %}
+{% extends "base-form.njk" %}
 {% set hmpoPageKey = "abandonCheck" %}
+{% set isPageHeading = true %}
 
 {% block mainContent %}
   {{ super() }}

--- a/src/views/kbv/question.html
+++ b/src/views/kbv/question.html
@@ -1,7 +1,6 @@
 {% extends "base-form.njk" %}
 {% from "hmpo-radios/macro.njk" import hmpoRadios %}
 
-{% set hmpoPageKey = "simplifiedQuestion" %}
 {% set gtmJourney = "kbv - middle" %}
 
 {% set hmpoTitle = question.label %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1470,14 +1470,17 @@ destroy@1.2.0:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
-di-ipv-cri-common-express@alphagov/di-ipv-cri-common-express.git#v0.0.31:
-  version "0.0.31"
-  uid d852eb02f9314fd60bc6fa1bc20bff677550bada
-  resolved "https://codeload.github.com/alphagov/di-ipv-cri-common-express/tar.gz/d852eb02f9314fd60bc6fa1bc20bff677550bada"
+di-ipv-cri-common-express@alphagov/di-ipv-cri-common-express.git#v0.0.36:
+  version "0.0.36"
+  resolved "https://codeload.github.com/alphagov/di-ipv-cri-common-express/tar.gz/65b40da6eb86c2f8b98e3c06426d81837fb27b97"
   dependencies:
     hmpo-logger "6.1.1"
-    i18next "^21.9.2"
+    i18next "21.10.0"
     i18next-fs-backend "^1.1.5"
+    i18next-http-middleware "3.2.1"
+    i18next-sync-fs-backend "1.1.1"
+    lodash.differencewith "4.5.0"
+    lodash.frompairs "4.0.1"
 
 diff@5.0.0:
   version "5.0.0"
@@ -2510,7 +2513,20 @@ i18next-fs-backend@^1.1.5:
   resolved "https://registry.yarnpkg.com/i18next-fs-backend/-/i18next-fs-backend-1.1.5.tgz#dcbd8227b1c1e4323b3c40e269d4762e8313d9e5"
   integrity sha512-raTel3EfshiUXxR0gvmIoqp75jhkj8+7R1LjB006VZKPTFBbXyx6TlUVhb8Z9+7ahgpFbcQg1QWVOdf/iNzI5A==
 
-i18next@^21.9.2:
+i18next-http-middleware@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/i18next-http-middleware/-/i18next-http-middleware-3.2.1.tgz#a0dff150de2273ec650da67336ad882eef58d179"
+  integrity sha512-zBwXxDChT0YLoTXIR6jRuqnUUhXW0Iw7egoTnNXyaDRtTbfWNXwU0a53ThyuRPQ+k+tXu3ZMNKRzfLuononaRw==
+
+i18next-sync-fs-backend@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/i18next-sync-fs-backend/-/i18next-sync-fs-backend-1.1.1.tgz#d1fb28545918e899b59feccc61adb4b9f5593a04"
+  integrity sha512-IoJCGid/NLqPFp+2qsumwOy1hG6jENKSIW9BozHL/3ZsjunH0P7iZLRMADljIuFntKlA63suPIPJWGR2SkxLIg==
+  dependencies:
+    js-yaml "3.13.1"
+    json5 "0.5.0"
+
+i18next@21.10.0:
   version "21.10.0"
   resolved "https://registry.yarnpkg.com/i18next/-/i18next-21.10.0.tgz#85429af55fdca4858345d0e16b584ec29520197d"
   integrity sha512-YeuIBmFsGjUfO3qBmMOc0rQaun4mIpGKET5WDwvu8lU7gvwpcariZLNtL0Fzj+zazcHUrlXHiptcFhBMFaxzfg==
@@ -2895,6 +2911,14 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
+js-yaml@3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@4.0.x:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.0.0.tgz#f426bc0ff4b4051926cd588c71113183409a121f"
@@ -2941,6 +2965,11 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
+
+json5@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.0.tgz#9b20715b026cbe3778fd769edccd822d8332a5b2"
+  integrity sha512-WDgahySBucTVnQuzQHoVh6BKKg3TFBUExSwYOPwA4it9xtspn3erHYkdEx1AXXkHN38L7O6v6lmqLiXh/GnxhA==
 
 json5@^2.2.1:
   version "2.2.1"
@@ -3074,10 +3103,20 @@ lodash-es@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
+lodash.differencewith@4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.differencewith/-/lodash.differencewith-4.5.0.tgz#bafafbc918b55154e179176a00bb0aefaac854b7"
+  integrity sha512-/8JFjydAS+4bQuo3CpLMBv7WxGFyk7/etOAsrQUCu0a9QVDemxv0YQ0rFyeZvqlUD314SERfNlgnlqqHmaQ0Cg==
+
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==
+
+lodash.frompairs@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.frompairs/-/lodash.frompairs-4.0.1.tgz#bc4e5207fa2757c136e573614e9664506b2b1bd2"
+  integrity sha512-dvqe2I+cO5MzXCMhUnfYFa9MD+/760yx2aTAN1lqEcEkf896TxgrX373igVdqSJj6tQd0jnSLE1UMuKufqqxFw==
 
 lodash.get@^4.4.2:
   version "4.4.2"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Switch from using hmpo-i18n to i18next so that we can take advantage of cookie domains and interpolation.

This PR uses the i18next middleware exported from common-express, and updates templates with the minimal changes required to use the new library.

It also contains the cookie domain setting. 



<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
