### PR TITLE
Fix missing translations behaviour

### DIFF
--- a/src/presenters/question-to-hint.js
+++ b/src/presenters/question-to-hint.js
@@ -2,9 +2,13 @@ module.exports = function (question, translate) {
   const key = `fields.${question.questionID}.hint`;
   const hint = translate(key);
 
-  if (hint && hint !== key) {
+  if (hint && !hint.includes(question.questionID)) {
     return hint;
   }
 
-  return question?.toolTip;
+  if (question?.toolTip) {
+    return question?.toolTip;
+  }
+
+  return " ";
 };

--- a/src/presenters/question-to-hint.test.js
+++ b/src/presenters/question-to-hint.test.js
@@ -39,13 +39,24 @@ describe("question-to-hint", () => {
     });
   });
 
-  context("with fallback translation key behaviour", () => {
+  context("with fallback to data behaviour", () => {
     it("should fallback to using tooltip", () => {
       translate.returns("fields.Q00.hint");
 
       const result = presenters.questionToHint(question, translate);
 
       expect(result).to.equal("question toolTip");
+    });
+  });
+
+  context("with missing key and data behaviour", () => {
+    it("should fallback to using tooltip", () => {
+      translate.returns("fields.Q00.hint");
+      question.toolTip = "";
+
+      const result = presenters.questionToHint(question, translate);
+
+      expect(result).to.equal(" ");
     });
   });
 });

--- a/src/presenters/question-to-legend.js
+++ b/src/presenters/question-to-legend.js
@@ -2,7 +2,7 @@ module.exports = function (question, translate) {
   const key = `fields.${question.questionID}.legend`;
   const legend = translate(key);
 
-  if (legend && legend !== key) {
+  if (legend && !legend.includes(question.questionID)) {
     return legend;
   }
 

--- a/src/presenters/question-to-legend.test.js
+++ b/src/presenters/question-to-legend.test.js
@@ -39,7 +39,7 @@ describe("question-to-hint", () => {
     });
   });
 
-  context("with fallback translation key behaviour", () => {
+  context("with fallback to data behaviour", () => {
     it("should fallback to using tooltip from question", () => {
       translate.returns("fields.Q00.legend");
 

--- a/src/presenters/question-to-radios.js
+++ b/src/presenters/question-to-radios.js
@@ -7,6 +7,7 @@ module.exports = function (question, translate) {
     id: question?.questionID,
     name: question?.questionID,
     label: questionToLegend(question, translate),
+    legend: questionToLegend(question, translate),
     fieldset: {
       legend: {
         isPageHeading: true,

--- a/src/presenters/question-to-radios.test.js
+++ b/src/presenters/question-to-radios.test.js
@@ -35,6 +35,11 @@ describe("question-to-radios", () => {
       "In which month and year did you open one of your current accounts"
     );
   });
+  it("should set legend label", () => {
+    expect(config.legend).to.equal(
+      "In which month and year did you open one of your current accounts"
+    );
+  });
   it("should set fieldset", () => {
     expect(config.fieldset).to.deep.equal({
       legend: {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

`hmpo-i18n` returns empty strings for missing keys, and `i18next` returns the keys.

This PR returns the appropriate hint or title for both libraries.

It also should fix the issue with a locales file wanting to override a hint text with no value.

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
