### PR TITLE
BAU: Fix link in readme markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ yarn install
 
 ## Precommit Hooks
 
-Install `pre-commit` from (here)[https://pre-commit.com/]
+Install `pre-commit` from [here](https://pre-commit.com/)
 
 Run `pre-commit install` to install pre-commit hooks locally.
 


### PR DESCRIPTION
This change, somewhat to my surprise has broken the team manual.

Turns out the slight misformatting in the markdown is getting slurpped up by the team manual for [pages like
this](https://di-team-manual.london.cloudapps.digital/code/di-ipv-cri-address-front/index.html#di-ipv-cri-address-front).

Which in turn is then getting checked with html-proofer. Which reports the markdown error as a bad link and errors.

This means the team manual isn't building and can't be deployed.

This is a bit of an odd situation. Quick fix is to amend the markdown here. But I think in the long run we should stop html-proofer from checking everyone's README pages, if they're broken that should be down to teams to fix!

See [1] & [2]

[1]: https://gds.slack.com/archives/CAC6S0UHK/p1667583411670329
[2]: https://github.com/alphagov/digital-identity-team-manual/actions/runs/3395659486/jobs/5645822868