### PR TITLE
PYIC-2249 Update service name

### DIFF
--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -10,8 +10,8 @@ govuk:
   skipLink: "Neidio i'r prif gynnwys"
   cookie:
     cookieBanner:
-      title: "Cwcis ar gyfrif GOV.UK"
-      heading: "Cwcis ar gyfrif GOV.UK"
+      title: "Cwcis ar GOV.UK One Login"
+      heading: "Cwcis ar GOV.UK One Login"
       paragraph1: "Rydym yn defnyddio rhai cwcis hanfodol i wneud i'r gwasanaeth hwn weithio."
       paragraph2: "Hoffem hefyd ddefnyddio cwcis dadansoddi er mwyn i ni allu deall sut rydych yn defnyddio'r gwasanaeth a gwneud gwelliannau."
       buttonAcceptText: "Derbyn cwcis dadansoddi"
@@ -54,7 +54,7 @@ error:
     subTitle: "Ni allwn brofi pwy ydych chi ar hyn o bryd."
     subHeading: "Beth allwch chi ei wneud"
     description: "Ewch yn ôl i'r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio'ch peiriant chwilio neu ddod o hyd iddo o hafan GOV.UK."
-    contactMeLink: "Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd)"
+    contactMeLink: "Cysylltwch â’r tîm GOV.UK One Login (agor mewn tab newydd)"
     buttonText: "Ewch i hafan GOV.UK"
     buttonLink: "https://www.gov.uk/"
 validation:

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -22,4 +22,4 @@ abandonCheck:
   h1: "Rhaid i chi ateb pob cwestiwn diogelwch i brofi pwy ydych chi"
   content:
     - "Ni allwch hepgor unrhyw gwestiynau."
-  contact: "<p><a href='https://signin.account.gov.uk/contact-us?supportType=PUBLIC' class='govuk-link' rel='noreferrer noopener' target='_blank'>Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd)</a></p>"
+  contact: "<p><a href='https://signin.account.gov.uk/contact-us?supportType=PUBLIC' class='govuk-link' rel='noreferrer noopener' target='_blank'>Cysylltwch â’r tîm GOV.UK One Login (agor mewn tab newydd)</a></p>"

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -11,8 +11,8 @@ govuk:
   skipLink: Skip to main content
   cookie:
     cookieBanner:
-      title: "Cookies on GOV.UK account"
-      heading: "Cookies on GOV.UK account"
+      title: "Cookies on GOV.UK One Login"
+      heading: "Cookies on GOV.UK One Login"
       paragraph1: "We use some essential cookies to make this service work."
       paragraph2: "We’d also like to use analytics cookies so we can understand how you use the service and make improvements."
       buttonAcceptText: "Accept analytics cookies"
@@ -55,7 +55,7 @@ error:
     subTitle: We cannot prove your identity right now.
     subHeading: What can you do
     description: Go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
-    contactMeLink: Contact the GOV.UK account team (opens in a new tab)
+    contactMeLink: Contact the GOV.UK One Login team (opens in a new tab)
     buttonText: Go to the GOV.UK homepage
     buttonLink: https://www.gov.uk/
 validation:

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -25,4 +25,4 @@ abandonCheck:
   h1: You must answer all security questions to prove your identity
   content:
     - You cannot skip any questions.
-  contact: "<p><a href='https://signin.account.gov.uk/contact-us?supportType=PUBLIC' class='govuk-link' rel='noreferrer noopener' target='_blank'>Contact the GOV.UK account team (opens in a new tab)</a></p>"
+  contact: "<p><a href='https://signin.account.gov.uk/contact-us?supportType=PUBLIC' class='govuk-link' rel='noreferrer noopener' target='_blank'>Contact the GOV.UK One Login team (opens in a new tab)</a></p>"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

The product name is being changed from **GOV.UK Account** to **GOV.UK One Login**. The code in this PR updates any appearance of the name in the source code, including content which may be hidden from the user (e.g the cookie banner).

### What changed

`locales/en/default.yml` and `locales/en/pages.yml` have been updated.

### Why did it change

The user should see a consistent name for the service throughout their journey.

### Issue tracking

- [PYIC-2282](https://govukverify.atlassian.net/browse/PYIC-2282) - a subticket of [PYIC-2249](https://govukverify.atlassian.net/browse/PYIC-2249) for the journey-wide epic.

## Checklists

### Other considerations

- [ ] Welsh and English content are synchronised before the code is merged.


[PYIC-2282]: https://govukverify.atlassian.net/browse/PYIC-2282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PYIC-2249]: https://govukverify.atlassian.net/browse/PYIC-2249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ