### PR TITLE
OJ-1103 initial waf excluding owasp

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -29,6 +29,12 @@ Parameters:
     Type: String
     Default: "none"
 
+  # This will need to be changed per CRI
+  CriPublicApiExportName:
+    Description: "The exported API name from the CRI API stack"
+    Type: String
+    Default: "kbv-cri-api-v1-KBVApiGatewayId"
+
 Conditions:
   IsNotDevelopment: !Or
     - !Equals [ !Ref Environment, build ]
@@ -49,6 +55,195 @@ Mappings:
       AccountId: 652711504416
 
 Resources:
+
+  # These patterns may need changing per CRI
+  FrontWebPathsRegexPatternSet:
+    Type: "AWS::WAFv2::RegexPatternSet"
+    Properties:
+      Name: FrontendPathsRegexPatternSet
+      Scope: REGIONAL
+      RegularExpressionList:
+        - ^\/$
+        - ^\/favicon.ico$
+        - ^\/public\/images\/.*\.(ico|png)$
+        - ^\/public\/stylesheets\/.*\.css$
+        - ^\/public\/javascripts\/.*\.js$
+        - ^\/public\/fonts\/.*\.woff2$
+        - ^\/kbv\/[a-zA-Z0-9\-_]*$
+        - ^\/oauth2\/[a-zA-Z0-9\-_]*$
+
+  # These patterns may need changing per CRI
+  PublicApiPathsRegexPatternSet:
+    Type: "AWS::WAFv2::RegexPatternSet"
+    Properties:
+      Name: PublicApiPathsRegexPatternSet
+      Scope: REGIONAL
+      RegularExpressionList:
+        - ^\/$
+        - ^\/token$
+        - ^\/credential\/issue$
+
+  FrontWebACL:
+    Type: AWS::WAFv2::WebACL
+    Properties:
+      Description: Web ACL for Front end
+      Name:
+        Fn::Sub: ${AWS::StackName}-front-web-allowed-paths
+      # Block by default
+      DefaultAction:
+        Block: {}
+      Rules:
+        # Enable specific paths.
+        - Name: AllowedPaths
+          Action:
+            Allow: {}
+          Priority: 10
+          Statement:
+            RegexPatternSetReferenceStatement:
+              Arn: !GetAtt FrontWebPathsRegexPatternSet.Arn
+              FieldToMatch:
+                UriPath: {}
+              TextTransformations:
+                - Priority: 0
+                  Type: NONE
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName:
+              Fn::Sub: ${AWS::StackName}-front-web-allowed-paths-metric
+
+      Scope: REGIONAL
+      Tags:
+      - Key: Name
+        Value:
+          Fn::Sub: ${AWS::StackName}-Frontend-Web-ACL
+      VisibilityConfig:
+        SampledRequestsEnabled: true
+        CloudWatchMetricsEnabled: true
+        MetricName:
+          Fn::Sub: ${AWS::StackName}-web-frontend-metric
+
+  FrontWafLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName:
+        Fn::Sub: aws-waf-logs-${AWS::StackName}-web-front
+      RetentionInDays: 14
+
+  FrontWafLogging:
+    Type: AWS::WAFv2::LoggingConfiguration
+    Properties:
+      ResourceArn:
+        Fn::GetAtt:
+        - FrontWebACL
+        - Arn
+      LogDestinationConfigs:
+      - Fn::Sub: arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:aws-waf-logs-${AWS::StackName}-web-front
+      LoggingFilter:
+        DefaultBehavior: KEEP
+        Filters:
+        - Behavior: KEEP
+          Conditions:
+          - ActionCondition:
+              Action: BLOCK
+          Requirement: MEETS_ANY
+      RedactedFields:
+      - SingleHeader:
+          Name: password
+
+  PublicApiACL:
+    Type: AWS::WAFv2::WebACL
+    Properties:
+      Description: Web ACL for the PublicApi
+      Name:
+        Fn::Sub: ${AWS::StackName}-public-api-allowed-paths
+      # Block by default
+      DefaultAction:
+        Block: {}
+      Rules:
+        # Enable specific paths.
+        - Name: AllowedPaths
+          Action:
+            Allow: {}
+          Priority: 10
+          Statement:
+            RegexPatternSetReferenceStatement:
+              Arn: !GetAtt PublicApiPathsRegexPatternSet.Arn
+              FieldToMatch:
+                UriPath: {}
+              TextTransformations:
+                - Priority: 0
+                  Type: NONE
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName:
+              Fn::Sub: ${AWS::StackName}-public-api-allowed-paths-metric
+      Scope: REGIONAL
+      Tags:
+      - Key: Name
+        Value:
+          Fn::Sub: ${AWS::StackName}-public-api-acl
+      VisibilityConfig:
+        SampledRequestsEnabled: true
+        CloudWatchMetricsEnabled: true
+        MetricName:
+          Fn::Sub: ${AWS::StackName}-public-api-metric
+
+  PublicApiLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName:
+        Fn::Sub: aws-waf-logs-${AWS::StackName}-public-api
+      RetentionInDays: 14
+
+  PublicApiWafLogging:
+    Type: AWS::WAFv2::LoggingConfiguration
+    Properties:
+      ResourceArn:
+        Fn::GetAtt:
+        - PublicApiACL
+        - Arn
+      LogDestinationConfigs:
+      - Fn::Sub: arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:aws-waf-logs-${AWS::StackName}-public-api
+      LoggingFilter:
+        DefaultBehavior: KEEP
+        Filters:
+        - Behavior: KEEP
+          Conditions:
+          - ActionCondition:
+              Action: BLOCK
+          Requirement: MEETS_ANY
+      RedactedFields:
+      - SingleHeader:
+          Name: password
+
+  AlbFrontWebACLAssociation:
+    Type: AWS::WAFv2::WebACLAssociation
+    Properties:
+      ResourceArn:
+        Ref: LoadBalancer
+      WebACLArn:
+        Fn::GetAtt:
+        - FrontWebACL
+        - Arn
+
+  # The import will need to be updated for different CRI's and
+  # possibly additional associations added for additional API's
+  KbvApiGwCRIWAFAssociation:
+    Type: AWS::WAFv2::WebACLAssociation
+    Properties:
+      ResourceArn:
+        Fn::Join:
+        - ''
+        - - arn:aws:apigateway:eu-west-2::/restapis/
+          - Fn::ImportValue: !Sub "${CriPublicApiExportName}"
+          - Fn::Sub: /stages/${Environment}
+      WebACLArn:
+        Fn::GetAtt:
+        - PublicApiACL
+        - Arn
+
   # Security Groups for the ECS service and load balancer
   LoadBalancerSG:
     Type: 'AWS::EC2::SecurityGroup'


### PR DESCRIPTION
## Proposed changes

### What changed

Added initial WAF template to block all unhandled paths to the front end load balancer and public API rest gateway 

### Why did it change

To prevent attacks as per incident 59 - 2022-11-10 P4 CRI Cyber Security Incident Incident 

### Issue tracking

- [Incident Report 59](https://docs.google.com/document/d/1_ykKlV4DsO9CmmMypwWt6ZWfV99scaxT/edit?userstoinvite=john.pearce%40digital.cabinet-office.gov.uk&actionButton=1#heading=h.gjdgxs)

- [OJ-1103](https://govukverify.atlassian.net/browse/OJ-1103)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

Promotion to Integration and Production disabled to allow full testing beforehand


[OJ-1103]: https://govukverify.atlassian.net/browse/OJ-1103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ