### PR TITLE
oj-1103 kbv front exported load balancer arn

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -580,3 +580,9 @@ Outputs:
     Export:
       Name: !Sub "${AWS::StackName}-KBVFrontGatewayId"
     Value: !Ref ApiGwHttpEndpoint
+  KBVLoadBalancerArn:
+    Description: >-
+      The ARN of the Fargate Front End Load Balancer
+    Export:
+      Name: !Sub "${AWS::StackName}-LoadBalancer"
+    Value: !Ref LoadBalancer


### PR DESCRIPTION
## Proposed changes

### What changed

Added load balancer to exports

### Why did it change

The WAF template needs to be able to import the load balancer ARN to create the web ACL association 

### Issue tracking

- [OJ-1103](https://govukverify.atlassian.net/browse/OJ-1103)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-1103]: https://govukverify.atlassian.net/browse/OJ-1103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ