### PR TITLE
fix: update configure-aws-credentials to v2

### DIFF
--- a/.github/workflows/post-merge-to-build.yml
+++ b/.github/workflows/post-merge-to-build.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Set up AWS creds
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2

--- a/.github/workflows/post-merge-to-dev.yml
+++ b/.github/workflows/post-merge-to-dev.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Set up AWS creds
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.DEV_GH_ACTIONS_ROLE_ARN }}
           aws-region: eu-west-2


### PR DESCRIPTION
## Proposed changes

### What changed

The configure-aws-credentials action v1-node16 was failing due to a node12 reference which is no longer supported by GitHub. Version 2 has been released last week which resolves this issue. 

### Why did it change

To fix the failing workflows

### Issue tracking

- [OJ-1346-](https://govukverify.atlassian.net/browse/OJ-1346)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks